### PR TITLE
Rename some symbols

### DIFF
--- a/rtq.go
+++ b/rtq.go
@@ -42,6 +42,9 @@ func (m *MockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		m.unmatchRequests = append(m.unmatchRequests, req)
 		return nil, errors.New("mock is not registered")
 	}
+	if len(q.roundTripFuncs) == 0 {
+		return nil, errors.New("queue is found but it's empty")
+	}
 	// Retrieve the roundTrip from the queue and execute it
 	roundTrip := q.roundTripFuncs[0]
 	q.roundTripFuncs = q.roundTripFuncs[1:]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Renamed `RoundTripQueues` to `MockTransport` for improved clarity and naming consistency within the project.
	- Updated method receivers and fields to align with the renaming for better code readability.
	- Renamed the `roundTrips` field to `roundTripFuncs` for clearer understanding of its purpose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->